### PR TITLE
Remove TAO check from element timing & LCP reporting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -300,8 +300,7 @@ To <dfn>process an image that finished loading</dfn> given an {{Element}} |eleme
     1. If |root| is not a {{Document}}, return.
     1. Let |now| be the [=current high resolution time=] given |element|'s <a>relevant global object</a>.
     1. Let |record| be a [=pending image record=] with [=pending image record/element=] |element|, [=pending image record/request=] |imageRequest| and [=pending image record/loadTime=] |now|.
-    1. If |imageRequest| is a data URL [[RFC2397]], or the <a>timing allow check</a> succeeds for |imageRequest|'s resource, add |record| to |root|'s [=images pending rendering=].
-    1. Otherwise, [=report element timing=] given |root|, |now|, «|record|» and «».
+    1. Add |record| to |root|'s [=images pending rendering=].
 </div>
 
 Reporting paint timing {#sec-reporting-paint-timing}


### PR DESCRIPTION
The TAO check does not add any security measure, given rendering same-origin and cross-origin images in the same frame would result in the same renderTime.

Closes #104


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/pull/105.html" title="Last updated on Nov 4, 2024, 5:53 PM UTC (d5cfcf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/paint-timing/105/4809157...d5cfcf9.html" title="Last updated on Nov 4, 2024, 5:53 PM UTC (d5cfcf9)">Diff</a>